### PR TITLE
Include workaround for duplicate PCI devices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine as builder
 RUN apk add --no-cache git
-RUN git clone https://github.com/jovial/redfish_exporter /build && cd /build && git checkout feature/log_counts
+RUN git clone https://github.com/jovial/redfish_exporter /build && cd /build && git checkout 59d1061fb0370cf72e1f813dfcc425f139be49d7
 WORKDIR /build
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o main .
 FROM scratch


### PR DESCRIPTION
```
* [from Gatherer #2] collected metric "redfish_system_pcie_device_health_state" { label:<name:"hostname" value:"" > label:<name:"pcie_device" value:"Starship/Matisse PCIe Dummy Host Bridge" > label:<name:"pcie_device_id" value:"64-7" > label:<name:"resource" value:"pcie_device" > gauge:<value:1 > } was collected before with the same name and label values
```