### PR TITLE
Bump golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:rc-bullseye AS builder
+FROM golang:1.24.2 AS builder
 
 LABEL maintainer="Jennings Liu <jenningsloy318@gmail.com>"
 
@@ -17,7 +17,7 @@ RUN mkdir -p /go/src/github.com/ && \
     cd /go/src/github.com/stackhpc/redfish_exporter && \
     make build
 
-FROM golang:rc-bullseye
+FROM golang:1.24.2
 
 COPY --from=builder /go/src/github.com/stackhpc/redfish_exporter/build/redfish_exporter /usr/local/bin/redfish_exporter
 RUN mkdir /etc/prometheus


### PR DESCRIPTION
Builds were failing with the rc-bullseye release:

0.525 /go/src/github.com/stackhpc/redfish_exporter/go.mod:5: unknown directive: toolchain
0.526 make: *** [Makefile:35: build] Error 1